### PR TITLE
Mapping Transformations

### DIFF
--- a/src/Annotations/DoctrineEntity.php
+++ b/src/Annotations/DoctrineEntity.php
@@ -1,0 +1,11 @@
+<?php
+namespace Rezonant\MapperBundle\Annotations;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * @Annotation
+ */
+class DoctrineEntity extends Annotation {
+	public $id = 'id';
+}

--- a/src/Annotations/DoctrineEntityTransformation.php
+++ b/src/Annotations/DoctrineEntityTransformation.php
@@ -1,0 +1,25 @@
+<?php
+namespace Rezonant\MapperBundle\Annotations;
+use Rezonant\MapperBundle\Annotations\Transformation as AnnotationTransformation;
+use Rezonant\MapperBundle\Transformation\TransformationInterface as MapTransformationInterface;
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * @Annotation
+ */
+class DoctrineEntityTransformation extends Transformation {
+	public $id = 'id';
+	
+	public function applyAnnotation(AnnotationTransformation $annotation, MapTransformationInterface $transformation) {
+		$transformation->setEntityClass($annotation->value);
+		$transformation->setId($annotation->id);
+	}
+	
+	/**
+	 * Returns the class name, class, or service tag of the tranformation that this annotation applies
+	 * @return type
+	 */
+	public function getTransformation(){
+		return 'rezonant.mapper.doctrine_entity_transformation';
+	}
+}

--- a/src/Annotations/Transformation.php
+++ b/src/Annotations/Transformation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rezonant\MapperBundle\Annotations;
+use Rezonant\MapperBundle\Annotations\Transformation as AnnotationTransformation;
+use Rezonant\MapperBundle\Transformation\TransformationInterface as MapTransformationInterface;
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * @Annotation
+ */
+class Transformation extends Annotation{
+	
+	public function applyAnnotation(AnnotationTransformation $annotation, MapTransformationInterface $transformation) {
+		//this is were you would take information (if you have any) from the annotation and put it into the transformation
+	}
+	
+	/**
+	 * Returns the class, class name or service tag of the tranformation that this annotation applies
+	 * @return type
+	 */
+	public function getTransformation(){
+		return $this->value;
+	}
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -54,7 +54,7 @@ class Configuration implements ConfigurationInterface {
 									->scalarNode('type')->end()
 									->scalarNode('types')->end()
 									->scalarNode('map')->end()
-
+									->scalarNode('transformation')->end()
 								->end()
 							->end()
 						->end()

--- a/src/Exceptions/TransformationException.php
+++ b/src/Exceptions/TransformationException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rezonant\MapperBundle\Exceptions;
+
+class TransformationException extends \Exception {
+	public function __construct($type) {
+		parent::__construct("Transformation Failed: $type");
+	}
+}

--- a/src/Map/Map.php
+++ b/src/Map/Map.php
@@ -17,6 +17,12 @@ class Map {
 			$newField->setSource($field->getDestination());
 			$newField->setDestination($field->getSource());
 			
+			//get the forward transformation and flip its direction
+			if($field->getTransformation()){
+				$invertTransformation = $field->getTransformation()->invert();
+				$newField->setTransformation($invertTransformation);
+			}
+			
 			if ($field->getSubmap()) {
 				$newField->setMap($field->getSubmap()->invert());
 			}

--- a/src/Map/MapField.php
+++ b/src/Map/MapField.php
@@ -56,7 +56,14 @@ class MapField {
 		$this->submap = $submap;
 	}
 	
+	/**
+	 * When you pass in an object it will be cloned to ensure that it will not change
+	 * @param type $transformation
+	 */
 	function setTransformation($transformation){
+		if($transformation){
+			$transformation = clone $transformation;
+		}
 		$this->transformation = $transformation;
 	}
 }

--- a/src/Map/MapField.php
+++ b/src/Map/MapField.php
@@ -1,16 +1,32 @@
 <?php
 
 namespace Rezonant\MapperBundle\Map;
+use Rezonant\MapperBundle\Transformation\TransformationInterface;
 
 class MapField {
 	
 	public function __construct()
 	{
 	}
-	
+	/**
+	 *
+	 * @var Reference
+	 */
 	private $source;
+	
+	/**
+	 *
+	 * @var Reference
+	 */
 	private $destination;
+	
 	private $submap;
+	
+	/**
+	 *
+	 * @var TransformationInterface 
+	 */
+	private $transformation;
 	
 	function getSource() {
 		return $this->source;
@@ -23,6 +39,10 @@ class MapField {
 	function getSubmap() {
 		return $this->submap;
 	}
+	
+	function getTransformation() {
+		return $this->transformation;
+	}
 
 	function setSource($source) {
 		$this->source = $source;
@@ -34,5 +54,9 @@ class MapField {
 
 	function setSubmap($submap) {
 		$this->submap = $submap;
+	}
+	
+	function setTransformation($transformation){
+		$this->transformation = $transformation;
 	}
 }

--- a/src/MapBuilder.php
+++ b/src/MapBuilder.php
@@ -4,6 +4,7 @@ namespace Rezonant\MapperBundle;
 use Rezonant\MapperBundle\Map\Map;
 use Rezonant\MapperBundle\Map\MapField;
 use Rezonant\MapperBundle\Map\Reference;
+use Rezonant\MapperBundle\Transformation\TransformationInterface;
 
 class MapBuilder {
 	private $fields = array();
@@ -14,12 +15,13 @@ class MapBuilder {
 	 * @param Map $map
 	 * @return MapBuilder
 	 */
-	public function field(Reference $source, Reference $dest, Map $map = NULL)
+	public function field(Reference $source, Reference $dest, Map $map = NULL, TransformationInterface $transformation = NULL)
 	{
 		$mapField = new MapField();
 		$mapField->setSource($source);
 		$mapField->setDestination($dest);
 		$mapField->setSubmap($map);
+		$mapField->setTransformation($transformation);
 		$this->fields[] = $mapField;
 		
 		return $this;

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -88,6 +88,11 @@ class Mapper {
 			$destinationField = $field->getDestination()->getFields();
 			$value = $this->get($source, $name);
 			
+			//if a transfermation exists apply it to the value
+			if($field->getTransformation()){
+				$value = $field->getTransformation()->transform($value, $field, $source, $destination);
+			}
+			
 			$destination = $this->deepSet($destination, $destinationField, $value, 
 					$field->getDestination()->getTypes(), $field->getSubmap());
 		}

--- a/src/Providers/AnnotationMapProvider.php
+++ b/src/Providers/AnnotationMapProvider.php
@@ -7,10 +7,11 @@ use Rezonant\MapperBundle\MapBuilder;
 use Rezonant\MapperBundle\Map\Reference;
 use Rezonant\MapperBundle\Utilities\Reflector;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Rezonant\MapperBundle\Exceptions\TransformationException;
 
 class AnnotationMapProvider extends MapProvider {
 	
-	public function __construct(Reader $reader, ContainerInterface $container) {
+	public function __construct(Reader $reader, ContainerInterface $container = null) {
 		$this->annotationReader = $reader;
 		$this->pathParser = new PathParser();
 		$this->reflector = new Reflector();
@@ -61,14 +62,14 @@ class AnnotationMapProvider extends MapProvider {
 	public function mapFromModel($modelOrClass, $entityOrClass) {
 		$class = new \ReflectionClass($modelOrClass);
 		$annotationName = 'Rezonant\\MapperBundle\\Annotations\\MapTo';
-		$doctrineEntityAnnotationName = 'Rezonant\\MapperBundle\\Annotations\\DoctrineEntity';
+		$transformationAnnotationName = 'Rezonant\\MapperBundle\\Annotations\\Transformation';
 		$map = new MapBuilder();
 		$destinationClass = new \ReflectionClass($entityOrClass);
 		
 		foreach ($class->getProperties() as $property) {
 			$annotation = $this->annotationReader->getPropertyAnnotation($property, $annotationName);
+			$transformationAnnotation = $this->annotationReader->getPropertyAnnotation($property, $transformationAnnotationName);
 			
-			$doctrineEntityAnnotation = $this->annotationReader->getPropertyAnnotation($property, $doctrineEntityAnnotationName);
 			
 			// Resolve the type of this property for submapping later.
 			
@@ -86,14 +87,8 @@ class AnnotationMapProvider extends MapProvider {
 			else if ($destinationClass->hasProperty($property->name))
 				$destinationField = $property->name;
 			
-			//figure out if there is a transformation
-			$transformation = null;
-			if($doctrineEntityAnnotation){
-				//get the doctrine entity tranformation rezonant.mapper.doctrine_entity_transformation
-				$transformation = $this->container->get('rezonant.mapper.doctrine_entity_transformation');
-				$transformation->setEntityClass($doctrineEntityAnnotation->value);
-				$transformation->setId($doctrineEntityAnnotation->id);
-			}
+			//Get transformation if there is one
+			$transformation = $this->getTransformationFromAnnotation($transformationAnnotation);
 			
 			// Resolve the destination field's type for generating a submap.
 			
@@ -114,6 +109,44 @@ class AnnotationMapProvider extends MapProvider {
 		}
 		
 		return $map->build();
+	}
+	
+	private function getTransformationFromAnnotation($transformationAnnotation){
+		if(!$transformationAnnotation){
+			return null;
+		}
+		
+		if(!$transformationAnnotation instanceof \Rezonant\MapperBundle\Annotations\Transformation){
+			throw new TransformationException("Transformation annotations must an instance of \Rezonant\MapperBundle\Annotations\Transformation");
+		}
+		
+		$resolvedTransformation = null;
+		
+		$transformation = $transformationAnnotation->getTransformation();
+		
+		if(is_object($transformation)){
+			$resolvedTransformation = $transformation;
+		}
+		
+		if(class_exists($transformation)){
+			$resolvedTransformation = new $transformation();
+		}
+		
+		if(is_string($transformation) && $this->container->has($transformation)){
+			$resolvedTransformation = $this->container->get($transformation);
+		}
+		
+		if(!$resolvedTransformation){
+			throw new TransformationException("Could not resolve tranformation from the transformation annotation");
+		}
+		
+		if(!$resolvedTransformation instanceof \Rezonant\MapperBundle\Transformation\TransformationInterface){
+			throw new TransformationException("Tranformations must be a instance of \Rezonant\MapperBundle\Transformation\TransformationInterface");
+		}
+		
+		$transformationAnnotation->applyAnnotation($transformationAnnotation, $resolvedTransformation);
+		
+		return $resolvedTransformation;
 	}
 	
 	private function isStandard($object)

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -16,7 +16,7 @@ services:
         
     rezonant.mapper.annotation_map_provider:
         class: Rezonant\MapperBundle\Providers\AnnotationMapProvider
-        arguments: ['@annotation_reader']
+        arguments: ['@annotation_reader', '@service_container']
         
     rezonant.mapper.config_map_provider.maps:
         synthetic: true
@@ -24,3 +24,7 @@ services:
     rezonant.mapper.config_map_provider:
         class: Rezonant\MapperBundle\Providers\ConfigMapProvider
         arguments: ['%rezonant.mapper.providers.config.maps%']
+        
+    rezonant.mapper.doctrine_entity_transformation:
+        class: Rezonant\MapperBundle\Transformation\DoctrineEntityTransformation
+        arguments: ['@doctrine']

--- a/src/Tests/Fixtures/FixtureC/FixtureC.php
+++ b/src/Tests/Fixtures/FixtureC/FixtureC.php
@@ -1,0 +1,122 @@
+<?php
+namespace Rezonant\MapperBundle\Tests\Fixtures\FixtureC;
+use Rezonant\MapperBundle\Annotations as Mapper;
+use Rezonant\MapperBundle\Annotations\Transformation as TransformationAnnotation;
+use Rezonant\MapperBundle\Transformation\AbstractTransformation;
+use Doctrine\Common\Annotations\Annotation;
+
+class FixtureC { }
+	class Source {
+		/**
+		 * @Mapper\MapTo("dPower")
+		 * @Mapper\Transformation("Rezonant\MapperBundle\Tests\Fixtures\FixtureC\SquaredTransformation")
+		 * @var string
+		 */
+		public $sPower;
+		
+		/**
+		 * @Mapper\MapTo("dName")
+		 * @Rezonant\MapperBundle\Tests\Fixtures\FixtureC\ProductTransformationAnnotaion("3")
+		 * @var string
+		 */
+		public $sRank;
+		
+		/**
+		 * @Mapper\MapTo("dName")
+		 * @Mapper\Transformation("Rezonant\MapperBundle\Tests\Fixtures\FixtureC\SquaredTransformation")
+		 * @var string
+		 */
+		public $sLevel;
+		
+		public $sDescription;
+	}
+
+	class Destination {
+
+		private $dPower;
+		
+		private $dRank;
+		
+		private $dLevel;
+		
+		private $dDescription;
+		
+		public function getDPower() {
+			return $this->dPower;
+		}
+
+		public function getDRank() {
+			return $this->dRank;
+		}
+
+		public function getDLevel() {
+			return $this->dLevel;
+		}
+
+		public function getDDescription() {
+			return $this->dDescription;
+		}
+
+		public function setDPower($dPower) {
+			$this->dPower = $dPower;
+		}
+
+		public function setDRank($dRank) {
+			$this->dRank = $dRank;
+		}
+
+		public function setDLevel($dLevel) {
+			$this->dLevel = $dLevel;
+		}
+
+		public function setDDescription($dDescription) {
+			$this->dDescription = $dDescription;
+		}
+		
+	}
+	
+	class SquaredTransformation extends AbstractTransformation {
+		public function forward($sourceFieldValue, $field, $source, $destination){
+			return pow($sourceFieldValue, 2);
+		}
+
+		public function reverse($destinationFieldValue, $field, $source, $destination){
+			return sqrt($destinationFieldValue);
+		}
+	}
+
+	/**
+	* @Annotation
+	*/
+	class ProductTransformationAnnotaion extends TransformationAnnotation {
+		public $multiply = 0;
+	
+		public function parseAnnotation(AnnotationTransformation $annotation, MapTransformationInterface $transformation) {
+			$transformation->setMultiply($annotation->multiply);
+		}
+		
+		public function getTransformation(){
+			return new ProductTransformation();
+		}
+	}
+	
+	class ProductTransformation extends AbstractTransformation {
+		private $multiply = 0;
+		
+		public function getMultiply() {
+			return $this->multiply;
+		}
+
+		public function setMultiply($multiply) {
+			$this->multiply = $multiply;
+		}
+
+				
+		public function forward($sourceFieldValue, $field, $source, $destination){
+			return ($sourceFieldValue * $this->getMultiply());
+		}
+
+		public function reverse($destinationFieldValue, $field, $source, $destination){
+			return ($destinationFieldValue / $this->getMultiply());
+		}
+	}

--- a/src/Transformation/AbstractTransformation.php
+++ b/src/Transformation/AbstractTransformation.php
@@ -1,0 +1,57 @@
+<?php
+namespace Rezonant\MapperBundle\Transformation;
+use Rezonant\MapperBundle\Map\Reference;
+/**
+ * TransformationInterface.
+ *
+ * @author Nathan Erickon
+ */
+abstract class AbstractTransformation implements TransformationInterface {
+	
+	private $direction = 1;
+	
+	public function getDirection(){
+		return $this->direction;
+	}
+	
+	public function setDirection($direction){
+		$this->direction = $direction;
+	}
+	
+	public function invert(){
+		if($this->getDirection() == self::FORWARD){
+			$this->setDirection(self::REVERSE);
+		}
+		else if ($this->getDirection() == self::REVERSE){
+			$this->setDirection(self::FORWARD);
+		}
+		return $this;
+	}
+	
+	public function transform($value, $field, $source, $destination){
+		if($this->getDirection() == self::FORWARD){
+			return $this->forward($value, $field, $source, $destination);
+		}
+		else if ($this->getDirection() == self::REVERSE){
+			return $this->reverse($value, $field, $source, $destination);
+		}
+	}
+	
+	/**
+	 * When mapping source to destination the source field value is passed in and new value will be expected to be returned
+	 * @param type $sourceFieldValue
+	 * @return type Transformed $sourceFieldValue
+	 */
+	public function forward($sourceFieldValue, $field, $source, $destination){
+		return $sourceFieldValue;
+	}
+	
+	/**
+	 * When mapping destination to source the destination field value is passed in and new value will be expected to be returned
+	 * @param type $destinationFieldValue
+	 * @return type Transformed $sourceFieldValue
+	 */
+	public function reverse($destinationFieldValue, $field, $source, $destination){
+		return $destinationFieldValue;
+	}
+}

--- a/src/Transformation/DoctrineEntityTransformation.php
+++ b/src/Transformation/DoctrineEntityTransformation.php
@@ -1,0 +1,93 @@
+<?php
+namespace Rezonant\MapperBundle\Transformation;
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\Common\Persistence\ObjectManager;
+use Rezonant\MapperBundle\Map\Reference;
+
+/**
+ * DoctrineEntityTransformation
+ *
+ * @author Nathan Erickon
+ */
+class DoctrineEntityTransformation extends AbstractTransformation {
+	
+	/**
+	 *
+	 * @var Registry
+	 */
+	private $doctrine = null;
+	
+	/**
+	 *
+	 * @var ObjectManager 
+	 */
+	private $entityManager = null;
+	
+	
+	private $entityClass = null;
+	
+	private $id = null;
+	
+	
+	public function __construct(Registry $doctrine) {
+		$this->doctrine = $doctrine;
+	}
+	
+	public function setEntityClass($entityClass){
+		$this->entityClass = $entityClass;
+	}
+	
+	public function getEntityClass(){
+		return $this->entityClass;
+	}
+	
+	public function setId($id){
+		$this->id = $id;
+	}
+	
+	public function getId(){
+		return $this->id;
+	}
+	
+	/**
+	 * et entity assuming the value is the id and then return it
+	 * @param type $sourceFieldValue
+	 * @param Reference $source
+	 * @param Reference $destination
+	 * @return type
+	 * @throws \Exception
+	 */
+	public function forward($sourceFieldValue, $field, $source, $destination) {
+		$entityClass = $this->getEntityClass();
+		
+		if(!$entityClass){
+			$entityClass = get_class($destination);
+		}
+		
+		$repository = $this->doctrine->getRepository($entityClass);
+		if(!$repository){
+			throw new \Exception('Could not resolve doctrine entity from destination type');
+		}
+		return $repository->find($sourceFieldValue);
+	}
+	
+	//get the primary key from the entity assuming the value is the entity
+	//might want to look up the primary key with the annotation reader
+	public function reverse($destinationFieldValue, $field, $source, $destination) {
+		if(!$destinationFieldValue){
+			return null;
+		}
+		
+		$fieldName = $this->getId();
+		$methodName = "get$fieldName";
+		
+		if (method_exists($destinationFieldValue, $methodName)){
+			return $destinationFieldValue->$methodName();
+		} else if (property_exists ($destinationFieldValue, $fieldName)){
+			return $destinationFieldValue->$fieldName;
+		}
+
+		return null;
+	}
+}
+

--- a/src/Transformation/DoctrineEntityTransformation.php
+++ b/src/Transformation/DoctrineEntityTransformation.php
@@ -3,6 +3,7 @@ namespace Rezonant\MapperBundle\Transformation;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Common\Persistence\ObjectManager;
 use Rezonant\MapperBundle\Map\Reference;
+use Rezonant\MapperBundle\Exceptions\TransformationException;
 
 /**
  * DoctrineEntityTransformation
@@ -16,12 +17,6 @@ class DoctrineEntityTransformation extends AbstractTransformation {
 	 * @var Registry
 	 */
 	private $doctrine = null;
-	
-	/**
-	 *
-	 * @var ObjectManager 
-	 */
-	private $entityManager = null;
 	
 	
 	private $entityClass = null;
@@ -66,7 +61,7 @@ class DoctrineEntityTransformation extends AbstractTransformation {
 		
 		$repository = $this->doctrine->getRepository($entityClass);
 		if(!$repository){
-			throw new \Exception('Could not resolve doctrine entity from destination type');
+			throw new TransformationException('Could not resolve doctrine entity from destination type');
 		}
 		return $repository->find($sourceFieldValue);
 	}
@@ -79,6 +74,11 @@ class DoctrineEntityTransformation extends AbstractTransformation {
 		}
 		
 		$fieldName = $this->getId();
+		
+		if(!$fieldName){
+			throw new TransformationException("Doctrine Transformation failed because the id was not set correctly.");
+		}
+		
 		$methodName = "get$fieldName";
 		
 		if (method_exists($destinationFieldValue, $methodName)){

--- a/src/Transformation/TransformationInterface.php
+++ b/src/Transformation/TransformationInterface.php
@@ -1,0 +1,54 @@
+<?php
+namespace Rezonant\MapperBundle\Transformation;
+use Rezonant\MapperBundle\Map\Reference;
+
+/**
+ * TransformationInterface.
+ *
+ * @author Nathan Erickon
+ */
+interface TransformationInterface {
+	
+	const FORWARD = 1;
+	const REVERSE = 2;
+	
+	/**
+	 * Gets current transformation direction state
+	 */
+	public function getDirection();
+	
+	/**
+	 * Sets current transformation direction state
+	 */
+	public function setDirection($direction);
+	
+	/**
+	 * flips the direction
+	 * @return this Description
+	 */
+	public function invert();
+	
+	/**
+	 * Decides what direction the transfermation is going and then returns the new value
+	 * @param type $value
+	 * @param type $source
+	 * @param type $destination
+	 */
+	public function transform($value, $field, $source, $destination);
+	
+	/**
+	 * When mapping source to destination the source field value is passed in and new value will be expected to be returned
+	 * @param type $sourceFieldValue
+	 * @param type $source
+	 * @param type $destination
+	 */
+	public function forward($sourceFieldValue, $field, $source, $destination);
+	
+	/**
+	 * When mapping destination to source the destination field value is passed in and new value will be expected to be returned
+	 * @param type $destinationFieldValue
+	 * @param type $source
+	 * @param type $destination
+	 */
+	public function reverse($destinationFieldValue, $field, $source, $destination);
+}

--- a/src/Utilities/Reflector.php
+++ b/src/Utilities/Reflector.php
@@ -18,16 +18,6 @@ class Reflector {
 	
 	
 	public function getType($field) {
-		if ($this->isPrimitiveType($field)) {
-			return $field;
-		}
-		
-		if (is_string($field)) {
-			throw new \InvalidArgumentException(
-					'Parameter $property cannot be a string unless the string is a valid primitive type'
-			);
-		}
-		
 		if($field instanceof \ReflectionMethod){
 			return $this->getTypeFromMethod($field);
 		}
@@ -37,10 +27,6 @@ class Reflector {
 		}
 		
 		return null;
-		
-		/*throw new \InvalidArgumentException(
-				'Could not evaluate the type of the field because it was not primitave or a supported reflection class'
-		);*/
 	}
 	
 	/**
@@ -53,10 +39,6 @@ class Reflector {
 	 */
 	public function getTypeFromProperty($property)
 	{
-		if ($this->isPrimitiveType($property)) {
-			return $property;
-		}
-		
 		if (is_string($property)) {
 			throw new \InvalidArgumentException(
 					'Parameter $property cannot be a string unless the string is a valid primitive type'
@@ -77,13 +59,8 @@ class Reflector {
 		return null;
 	}
 
-	//IN PROGRESS!!! TODO
 	public function getTypeFromMethod($method)
 	{
-		if ($this->isPrimitiveType($method)) {
-			return $method;
-		}
-		
 		if (is_string($method)) {
 			throw new \InvalidArgumentException(
 				'Parameter $property cannot be a string unless the string is a valid primitive type'

--- a/src/Utilities/Reflector.php
+++ b/src/Utilities/Reflector.php
@@ -16,6 +16,33 @@ class Reflector {
 	 */
 	private $annotationReader;
 	
+	
+	public function getType($field) {
+		if ($this->isPrimitiveType($field)) {
+			return $field;
+		}
+		
+		if (is_string($field)) {
+			throw new \InvalidArgumentException(
+					'Parameter $property cannot be a string unless the string is a valid primitive type'
+			);
+		}
+		
+		if($field instanceof \ReflectionMethod){
+			return $this->getTypeFromMethod($field);
+		}
+		
+		if($field instanceof \ReflectionProperty){
+			return $this->getTypeFromProperty($field);
+		}
+		
+		return null;
+		
+		/*throw new \InvalidArgumentException(
+				'Could not evaluate the type of the field because it was not primitave or a supported reflection class'
+		);*/
+	}
+	
 	/**
 	 * Get the designated class name from the given property
 	 * 
@@ -26,8 +53,9 @@ class Reflector {
 	 */
 	public function getTypeFromProperty($property)
 	{
-		if ($this->isPrimitiveType($property))
+		if ($this->isPrimitiveType($property)) {
 			return $property;
+		}
 		
 		if (is_string($property)) {
 			throw new \InvalidArgumentException(
@@ -44,7 +72,34 @@ class Reflector {
 				$property, 'JMS\\Serializer\\Annotation\\Type');
 		
 		if ($typeAnnotation)
+			return $typeAnnotation->name;
+		
+		return null;
+	}
+
+	//IN PROGRESS!!! TODO
+	public function getTypeFromMethod($method)
+	{
+		if ($this->isPrimitiveType($method)) {
+			return $method;
+		}
+		
+		if (is_string($method)) {
+			throw new \InvalidArgumentException(
+				'Parameter $property cannot be a string unless the string is a valid primitive type'
+			);
+		}
+		
+		$typeAnnotation = $this->annotationReader->getMethodAnnotation(
+				$method, 'Rezonant\\MapperBundle\\Annotations\\Type');
+		if ($typeAnnotation)
 			return $typeAnnotation->value;
+		
+		$typeAnnotation = $this->annotationReader->getMethodAnnotation(
+				$method, 'JMS\\Serializer\\Annotation\\Type');
+		
+		if ($typeAnnotation)
+			return $typeAnnotation->name;
 		
 		return null;
 	}


### PR DESCRIPTION
Added field mapping transformations, this will allow consumers to provide a forward and reverse transformations on a field. Along with the generic path for transformations I also added a doctrine specific built in transformation for database entity lookups from primary keys in the model as well as the reverse. Transformation annotation extension support was added as well for a clean way for consumers to add their own transformation annotations.
